### PR TITLE
Increase branch coverage on various stories

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -139,3 +139,8 @@ OutlinedDisabled.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByRole('button'));
   expect(canvas.getByRole('button')).toBeDisabled();
 };
+
+/**
+ * Default variant (not specified)
+ */
+export const DefaultVariant = Template.bind({});

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,11 +19,9 @@ export default {
   component: Dropdown,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   args: {
-    variant: 'outlined',
     placeholder: 'Default Dropdown',
     label: 'Label',
     helperText: 'Helper text',
-    disabled: false,
     error: false,
     readOnly: false,
     required: false,
@@ -140,3 +138,17 @@ FilledEndIcon.args = {
 };
 
 FilledEndIcon.parameters = Filled.parameters;
+
+/**
+ * Disabled
+ */
+export const Disabled = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Disabled.args = {
+  disabled: true,
+};
+
+/**
+ * Default variant (not specified)
+ */
+export const DefaultVariant = Template.bind({});

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -14,7 +14,6 @@ export default {
   component: Input,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   args: {
-    variant: 'outlined',
     placeholder: 'Default input',
     label: 'Label',
     helperText: 'Helper text',
@@ -146,3 +145,8 @@ FilledEndIcon.args = {
 };
 
 FilledEndIcon.parameters = Filled.parameters;
+
+/**
+ * Default variant (not specified)
+ */
+export const DefaultVariant = Template.bind({});

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -14,7 +14,6 @@ export default {
   component: Textarea,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   args: {
-    variant: 'outlined',
     placeholder: 'Default textarea',
     label: 'Label',
     helperText: 'Helper text',
@@ -144,3 +143,8 @@ FilledEndIcon.args = {
 };
 
 FilledEndIcon.parameters = Filled.parameters;
+
+/**
+ * Default variant (not specified)
+ */
+export const DefaultVariant = Template.bind({});


### PR DESCRIPTION
Couple args had to be removed from the templates to allow testing of the component with its default arguments. This is in case the person using the component doesn't happen to specify all those arguments. This didn't affect how the stories look on storybook, so I think the change is fine.

Also added a Dropdown story where the component is disabled, and it looks good (grayed out.) 

Branch coverage is now overall in good state.